### PR TITLE
ZMS-164

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,6 @@ exports.register = function () {
 };
 
 exports.load_wildduck_cfg = function () {
-
     this.cfg = this.config.get(
         'wildduck.yaml',
         {
@@ -588,7 +587,7 @@ exports.hook_rcpt = function (next, connection, params) {
 exports.real_rcpt_handler = function (next, connection, params) {
     const plugin = this;
     const txn = connection.transaction;
-    const remoteIp = connection.remote_ip;
+    const remoteIp = connection.remote.ip;
 
     const { recipients, forwards, users } = txn.notes.targets;
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -25,7 +25,7 @@ async function hookMail(plugin, connection, params) {
     try {
         spfResult = await checkSpf({
             resolver: plugin.resolver,
-            ip: connection.remote_ip, // SMTP client IP
+            ip: connection.remote.ip, // SMTP client IP
             helo: connection.hello?.host, // EHLO/HELO hostname
             sender: txn.notes.sender, // MAIL FROM address
             mta: connection.local?.host, // MX hostname

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -19,7 +19,7 @@ async function mail(plugin, connection, params) {
         _mail_action: 'mail_from',
         _from: txn.notes.sender,
         _queue_id: txn.uuid,
-        _ip: connection.remote_ip,
+        _ip: connection.remote.ip,
         _proto: txn.notes.transmissionType
     });
 


### PR DESCRIPTION
Renamed `remote_ip` to use `remote.ip`. According to new structure. Otherwise `remote_ip` shows undefined and thus all intra-domain emails (soft|hard)-fail the SPF check for example.